### PR TITLE
Fix points search if no points available

### DIFF
--- a/src/MondialRelay/Api/Client.php
+++ b/src/MondialRelay/Api/Client.php
@@ -80,7 +80,7 @@ class Client
             throw new ApiException();
         }
 
-        $details = $response->WSI4_PointRelais_RechercheResult->PointsRelais->PointRelais_Details;
+        $details = $response->WSI4_PointRelais_RechercheResult->PointsRelais->PointRelais_Details ?? [];
 
         if (!is_array($details)) {
             $details = [$details];


### PR DESCRIPTION
Prevent PHP error caused by passing an empty value to `PointFactory::create()`.
In some cases, the Mondial Relay API responds with `STAT = 0` but an inexisting `PointsRelais` key.